### PR TITLE
Reactive helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,17 @@ ember install ember-sparkles
 
 - ### [Changelog](CHANGELOG.md)
 
+
+
 ## Looking for help?
 If it is a bug [please open an issue on GitHub](http://github.com/LocusEnergy/ember-sparkles/issues).
 
 ## Usage
+
+
+## Updating the Demo site
+
+```
+ember github-pages:commit --message <some commit message>
+git push origin master
+```

--- a/addon/templates/components/ember-sparkles/bar-chart.hbs
+++ b/addon/templates/components/ember-sparkles/bar-chart.hbs
@@ -2,51 +2,50 @@
 
   {{!-- create x axis --}}
 
-  {{ember-d3-helpers/invoke (pipe
-    (d3-append 'g')
-    (d3-attr 'class' 'x axis')
-    ) d3el
+  {{shhh (compute (pipe
+      (d3-append 'g')
+      (d3-attr 'class' 'x axis')
+    ) d3el)
   }}
 
   {{!-- select / call x axis function on d3 selection --}}
 
   {{#with (ember-sparkles/axis xScale position='bottom' tickFormat=(or tick-format '%Y-%m-%d')) as |axis|}}
-    {{ember-d3-helpers/invoke (pipe
-      (d3-select-all '.x.axis')
-      (if with-transition (d3-transition transition) (d3-noop))
-      (d3-attr 'transform' (i 'translate(0,${h})' h=height))
-      (d3-call axis)
-      ) d3el
+    {{shhh (compute (pipe
+        (d3-select-all '.x.axis')
+        (if with-transition (d3-transition transition) (d3-noop))
+        (d3-attr 'transform' (i 'translate(0,${h})' h=height))
+        (d3-call axis)
+      ) d3el)
     }}
   {{/with}}
 
   {{!-- create y axis --}}
 
-  {{ember-d3-helpers/invoke (pipe
-    (d3-append 'g')
-    (d3-attr 'class' 'y axis')
-    (d3-append 'text')
-    (d3-attr 'transform' 'rotate(-90)')
-    (d3-attr 'y' 6)
-    (d3-attr 'dy' '0.7em')
-    (d3-style 'text-anchor' 'end')
-    (d3-text y-label)
-    ) d3el
+  {{shhh (compute (pipe
+      (d3-append 'g')
+      (d3-attr 'class' 'y axis')
+      (d3-append 'text')
+      (d3-attr 'transform' 'rotate(-90)')
+      (d3-attr 'y' 6)
+      (d3-attr 'dy' '0.7em')
+      (d3-style 'text-anchor' 'end')
+      (d3-text y-label)
+    ) d3el)
   }}
 
   {{!-- select / call y axis function on d3 selection --}}
 
   {{#with (ember-sparkles/axis yScale position='left' ticks=ticks width=width) as |axis|}}
-    {{ember-d3-helpers/invoke (pipe
-      (d3-select-all '.y.axis')
-      (if with-transition (d3-transition transition) (d3-noop))
-      (d3-call axis)
-      ) d3el
+    {{shhh (compute  (pipe
+        (d3-select-all '.y.axis')
+        (if with-transition (d3-transition transition) (d3-noop))
+        (d3-call axis)
+      ) d3el)
     }}
   {{/with}}
 
-  {{ember-d3-helpers/invoke
-    (d3-join 'rect' data
+  {{shhh (compute (d3-join 'rect' data
       enter=(pipe
         (d3-append 'rect')
         (d3-attr 'class' 'bar')
@@ -77,7 +76,7 @@
         (d3-attr 'y' height)
         (d3-remove)
       )
-    ) d3el
+    ) d3el)
   }}
 
 {{/if}}

--- a/addon/templates/components/ember-sparkles/grouped-bar-chart.hbs
+++ b/addon/templates/components/ember-sparkles/grouped-bar-chart.hbs
@@ -1,29 +1,29 @@
 {{#if d3el}}
   {{!-- x axis --}}
-  {{ember-d3-helpers/invoke (pipe
-    (d3-append 'g')
-    (d3-attr 'class' 'x axis')
-    ) d3el
+  {{shhh (compute (pipe
+      (d3-append 'g')
+      (d3-attr 'class' 'x axis')
+    ) d3el)
   }}
 
   {{#with (ember-sparkles/axis xScale
-    position='bottom'
-    tickFormat=(or tick-format '%Y-%m-%d')
-    responsiveSkipIdx=(or responsive-skip-idx 1)
+      position='bottom'
+      tickFormat=(or tick-format '%Y-%m-%d')
+      responsiveSkipIdx=(or responsive-skip-idx 1)
     ) as |axis|}}
 
-    {{ember-d3-helpers/invoke (pipe
+    {{shhh (compute (pipe
       (d3-select-all '.x.axis')
       (if with-transition (d3-transition transition) (d3-noop))
       (d3-attr 'transform' (i 'translate(0,${h})' h=height))
       (d3-call axis)
-      ) d3el
+      ) d3el)
     }}
 
   {{/with}}
 
   {{!-- y axis --}}
-  {{ember-d3-helpers/invoke (pipe
+  {{shhh (compute (pipe
     (d3-append 'g')
     (d3-attr 'class' 'y axis')
     (d3-append 'text')
@@ -31,25 +31,25 @@
     (d3-attr 'transform' 'rotate(-90)')
     (d3-style 'text-anchor' 'end')
     (d3-text y-label)
-    ) d3el
+    ) d3el)
   }}
 
   {{#with (ember-sparkles/axis yScale position='left' ticks=ticks width=width) as |axis|}}
-    {{ember-d3-helpers/invoke (pipe
+    {{shhh (compute (pipe
       (d3-select-all '.y.axis')
       (if with-transition (d3-transition transition) (d3-noop))
       (d3-call axis)
-      ) d3el
+      ) d3el)
     }}
   {{/with}}
 
   {{!-- position vertical label programmatically based on height; -0.4*height is a nice default --}}
-  {{ember-d3-helpers/invoke (pipe
+  {{shhh (compute (pipe
     (d3-select-all '.vertical-label')
     (if with-transition (d3-transition transition) (d3-noop))
     (d3-attr 'y' (or vertical-label-dy 6))
     (d3-attr 'x' (or vertical-label-dx (mult -0.4 height)))
-    ) d3el
+    ) d3el)
   }}
 
   {{#with (band-scale
@@ -90,37 +90,37 @@
 
     ) as |renderOptions|}}
 
-      {{ember-d3-helpers/dev-null (compute
-        (d3-join '.rect-group' data
-          enter=(pipe
-            (d3-append 'g')
-            (d3-attr 'class' 'rect-group')
-            (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
-            (d3-join 'rect' outputAccessor
-              enter=(pipe renderOptions.enterRect renderOptions.updateRect)
+        {{shhh (compute
+          (d3-join '.rect-group' data
+            enter=(pipe
+              (d3-append 'g')
+              (d3-attr 'class' 'rect-group')
+              (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
+              (d3-join 'rect' outputAccessor
+                enter=(pipe renderOptions.enterRect renderOptions.updateRect)
+              )
             )
-          )
 
-          update=(pipe
-            (d3-join 'rect' outputAccessor
-              enter=(pipe renderOptions.enterRect renderOptions.updateRect)
-              update=renderOptions.updateRect
-              exit=renderOptions.exitRect
+            update=(pipe
+              (d3-join 'rect' outputAccessor
+                enter=(pipe renderOptions.enterRect renderOptions.updateRect)
+                update=renderOptions.updateRect
+                exit=renderOptions.exitRect
+              )
+              (if with-transition (d3-transition transition) (d3-noop))
+              (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
             )
-            (if with-transition (d3-transition transition) (d3-noop))
-            (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
-          )
 
-          exit=(pipe
-            (d3-join 'rect' outputAccessor
-              update=renderOptions.exitRect
-              exit=renderOptions.exitRect
+            exit=(pipe
+              (d3-join 'rect' outputAccessor
+                update=renderOptions.exitRect
+                exit=renderOptions.exitRect
+              )
+              (if with-transition (d3-transition transition) (d3-noop))
+              (d3-remove)
             )
-            (if with-transition (d3-transition transition) (d3-noop))
-            (d3-remove)
-          )
-        )
-      d3el)}}
+          ) d3el)
+        }}
 
     {{/with}}
 
@@ -137,8 +137,7 @@
       d3el
     ) as |legend|}}
 
-      {{ember-d3-helpers/invoke
-        (d3-join 'rect' groupDomain
+      {{shhh (compute (d3-join 'rect' groupDomain
           enter=(pipe
             (d3-append 'rect')
             (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
@@ -161,11 +160,10 @@
             (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
             (d3-remove)
           )
-        )
-      legend }}
+        ) legend)
+      }}
 
-      {{ember-d3-helpers/invoke
-        (d3-join 'text' groupDomain
+      {{shhh (compute (d3-join 'text' groupDomain
           enter=(pipe
             (d3-append 'text')
             (d3-attr 'opacity' 0)
@@ -187,8 +185,8 @@
             (d3-attr 'opacity' 0)
             (d3-remove)
           )
-        )
-      legend }}
+        ) legend)
+      }}
 
     {{/with}}
   {{/if}}

--- a/addon/templates/components/ember-sparkles/line-chart.hbs
+++ b/addon/templates/components/ember-sparkles/line-chart.hbs
@@ -19,21 +19,21 @@
 
     {{!-- create x axis --}}
 
-    {{ember-d3-helpers/invoke (pipe
-      (d3-append 'g')
-      (d3-attr 'class' 'x axis')
-      (d3-attr 'transform' (i 'translate(0,${h})' h=height))
-      ) d3el
+    {{shhh (compute (pipe
+        (d3-append 'g')
+        (d3-attr 'class' 'x axis')
+        (d3-attr 'transform' (i 'translate(0,${h})' h=height))
+      ) d3el)
     }}
 
     {{!-- select / call x axis function on d3 selection --}}
 
     {{#with (ember-sparkles/axis options.xScale position='bottom' tickFormat='%Y-%m-%d') as |axis|}}
-      {{ember-d3-helpers/invoke (pipe
-        (d3-select-all '.x.axis')
-        (if with-transition (d3-transition options.transition) (d3-noop))
-        (d3-call axis)
-        ) d3el
+      {{shhh (compute (pipe
+          (d3-select-all '.x.axis')
+          (if with-transition (d3-transition options.transition) (d3-noop))
+          (d3-call axis)
+        ) d3el)
       }}
     {{/with}}
 
@@ -48,17 +48,16 @@
     {{!-- select / call y axis function on d3 selection --}}
 
     {{#with (ember-sparkles/axis options.yScale position='left' ticks=ticks) as |axis|}}
-      {{ember-d3-helpers/invoke (pipe
-        (d3-select-all '.y.axis')
-        (if with-transition (d3-transition options.transition) (d3-noop))
-        (d3-call axis)
-        ) d3el
+      {{shhh (compute (pipe
+          (d3-select-all '.y.axis')
+          (if with-transition (d3-transition options.transition) (d3-noop))
+          (d3-call axis)
+        ) d3el)
       }}
     {{/with}}
 
 
-    {{ember-d3-helpers/invoke
-      (d3-join '.line' data
+    {{shhh (compute (d3-join '.line' data
 
         enter=(pipe
           (d3-append 'path')
@@ -88,7 +87,7 @@
           (d3-remove)
         )
 
-      ) d3el
+      ) d3el)
     }}
 
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "ember-d3-helpers": "0.5.1",
     "ember-math-helpers": "1.0.0",
     "ember-resize": "0.0.13",
-    "ember-truth-helpers": "1.2.0"
+    "ember-truth-helpers": "1.2.0",
+    "ember-reactive-helpers": "0.2.0"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Eliminate the use of `dev-null` and `invoke` in favour of `shhh` helper from ember-reactive-helpers.

/cc @zigahertz 
