### PR TITLE
Removed use of map and d3-get

### DIFF
--- a/addon/helpers/ember-sparkles/map.js
+++ b/addon/helpers/ember-sparkles/map.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export function emberSparklesMap([ collection, callback ]) {
-  return collection.map(callback);
-}
-
-export default Ember.Helper.helper(emberSparklesMap);

--- a/addon/templates/components/ember-sparkles.hbs
+++ b/addon/templates/components/ember-sparkles.hbs
@@ -10,10 +10,10 @@
       width=innerWidth
       height=innerHeight
 
-      inputAccessor=(d3-get sparkled.inputKey)
-      valueAccessor=(d3-get sparkled.valueKey)
-      outputAccessor=(d3-get sparkled.outputKey)
-      groupAccessor=(d3-get sparkled.groupKey)
+      inputAccessor=(r/get sparkled.inputKey)
+      valueAccessor=(r/get sparkled.valueKey)
+      outputAccessor=(r/get sparkled.outputKey)
+      groupAccessor=(r/get sparkled.groupKey)
 
       xScale=(band-scale
         (map (r/get sparkled.inputKey) sparkled.data)

--- a/addon/templates/components/ember-sparkles.hbs
+++ b/addon/templates/components/ember-sparkles.hbs
@@ -16,7 +16,7 @@
       groupAccessor=(d3-get sparkled.groupKey)
 
       xScale=(band-scale
-        (ember-sparkles/map sparkled.data (d3-get sparkled.inputKey))
+        (map (r/get sparkled.inputKey) sparkled.data)
         (append 0 innerWidth)
         round=true
         padding=padding

--- a/app/helpers/ember-sparkles/map.js
+++ b/app/helpers/ember-sparkles/map.js
@@ -1,1 +1,0 @@
-export { default, emberSparklesMap } from 'ember-sparkles/helpers/ember-sparkles/map';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "glimmer"
   ],
   "dependencies": {
-    "ember-composable-helpers": "0.23.1",
+    "ember-composable-helpers": "0.27.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-d3-shape": "0.9.0",
     "ember-cli-htmlbars": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-math-helpers": "1.0.0",
     "ember-resize": "0.0.13",
     "ember-truth-helpers": "1.2.0",
-    "ember-reactive-helpers": "0.3.2"    
+    "ember-reactive-helpers": "0.3.5"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-math-helpers": "1.0.0",
     "ember-resize": "0.0.13",
     "ember-truth-helpers": "1.2.0",
-    "ember-reactive-helpers": "0.2.0"    
+    "ember-reactive-helpers": "0.3.2"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/dummy/app/templates/bar-chart.hbs
+++ b/tests/dummy/app/templates/bar-chart.hbs
@@ -3,8 +3,8 @@
 
   {{chart.bar-chart
     data=data
-    inputAccessor=(d3-get 'ts')
-    outputAccessor=(d3-get 'value')
+    inputAccessor=(r/get 'ts')
+    outputAccessor=(r/get 'value')
     ticks=5
     tick-format='%Y-%m-%d'
     y-label='value'

--- a/tests/dummy/app/templates/bar-chart.hbs
+++ b/tests/dummy/app/templates/bar-chart.hbs
@@ -10,7 +10,7 @@
     y-label='value'
 
     xScale=(band-scale
-      (ember-sparkles/map data (d3-get 'ts'))
+      (map (r/get 'ts') data)
       (append 0 chart.width)
       round=true
       padding=0.02

--- a/tests/integration/components/ember-sparkles/bar-chart-test.js
+++ b/tests/integration/components/ember-sparkles/bar-chart-test.js
@@ -46,8 +46,8 @@ test('it accepts data and generates rectangles', function(assert) {
     <svg height="100" width="100">
       {{ember-sparkles/bar-chart
         data=data
-        inputAccessor=(d3-get '0')
-        outputAccessor=(d3-get '1')
+        inputAccessor=(r 'object-at' 0)
+        outputAccessor=(r 'object-at' 1)
 
         xScale=(band-scale
           xDomain
@@ -107,8 +107,8 @@ test('data can be updated and removed', function(assert) {
     <svg height="100" width="100">
       {{ember-sparkles/bar-chart
         data=data
-        inputAccessor=(d3-get '0')
-        outputAccessor=(d3-get '1')
+        inputAccessor=(r 'object-at' '0')
+        outputAccessor=(r 'object-at' '1')
         xScale=(band-scale
           xDomain
           (append 0 100)

--- a/tests/integration/components/ember-sparkles/grouped-bar-chart-test.js
+++ b/tests/integration/components/ember-sparkles/grouped-bar-chart-test.js
@@ -22,8 +22,8 @@ test('it renders', function(assert) {
         with-transition=false
         data=data
         groupDomain=groupDomain
-        inputAccessor=(d3-get)
-        outputAccessor=(d3-get)
+        inputAccessor=(r/param)
+        outputAccessor=(r/param)
         xScale=(band-scale)
         yScale=(linear-scale)
       }}
@@ -120,10 +120,10 @@ test('accepts data and dynamically generates rectangles and legend', function(as
         data=data
         groupDomain=groupDomain
 
-        inputAccessor=(d3-get 'ts')
-        outputAccessor=(d3-get 'watts')
-        valueAccessor=(d3-get 'value')
-        groupAccessor=(d3-get 'name')
+        inputAccessor=(r/get 'ts')
+        outputAccessor=(r/get 'watts')
+        valueAccessor=(r/get 'value')
+        groupAccessor=(r/get 'name')
 
         xScale=(band-scale
           xDomain

--- a/tests/unit/helpers/ember-sparkles/map-test.js
+++ b/tests/unit/helpers/ember-sparkles/map-test.js
@@ -1,8 +1,0 @@
-import { emberSparklesMap } from 'dummy/helpers/ember-sparkles/map';
-import { module, test } from 'qunit';
-
-module('Unit | Helper | ember sparkles/map');
-
-test('it works', function(assert) {
-  assert.ok(emberSparklesMap instanceof Function);
-});


### PR DESCRIPTION
- Upgraded ember-reactive-helpers to 0.3.5
- Upgraded ember-composable-helpers to 0.27.0
- Replaced `d3-get` with `r/get` when get values from objects and `(r 'object-at')` when getting values from arrays

(Ignore branch name, I didn't to get to that yet)
