### PR TITLE
Use `{{d3-graph}}` component to render graphs

### DIFF
--- a/addon/components/ember-sparkles/bar-chart.js
+++ b/addon/components/ember-sparkles/bar-chart.js
@@ -1,21 +1,9 @@
 import Ember from 'ember';
-import { select } from 'd3-selection';
 import layout from '../../templates/components/ember-sparkles/bar-chart';
 
 export default Ember.Component.extend({
   layout,
-  tagName: 'g',
-  classNames: ['ember-sparkles--bar-chart'],
+  tagName: '',
 
-  'with-transition': true,
-
-  didInsertElement() {
-    this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, 'renderChart');
-  },
-
-  renderChart() {
-    let [ el ] = this.$().toArray();
-    this.set('d3el', select(el));
-  }
+  'with-transition': true
 });

--- a/addon/components/ember-sparkles/grouped-bar-chart.js
+++ b/addon/components/ember-sparkles/grouped-bar-chart.js
@@ -1,24 +1,12 @@
 import Ember from 'ember';
-import { select } from 'd3-selection';
 import layout from '../../templates/components/ember-sparkles/grouped-bar-chart';
 
 export default Ember.Component.extend({
   layout,
-  tagName: 'g',
-  classNames: ['ember-sparkles--grouped-bar-chart'],
+  tagName: '',
 
   'with-transition': true,
   'with-legend': true,
-
-  didInsertElement() {
-    this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, 'renderChart');
-  },
-
-  renderChart() {
-    let [ el ] = this.$().toArray();
-    this.set('d3el', select(el));
-  },
 
   // callback to position legend
   transformLegend(d, i) {

--- a/addon/components/ember-sparkles/line-chart.js
+++ b/addon/components/ember-sparkles/line-chart.js
@@ -1,21 +1,9 @@
 import Ember from 'ember';
-import { select } from 'd3-selection';
 import layout from '../../templates/components/ember-sparkles/line-chart';
 
 export default Ember.Component.extend({
   layout,
-  tagName: 'g',
-  classNames: ['ember-sparkles--line-chart'],
+  tagName: '',
 
-  'with-transition': true,
-
-  didInsertElement() {
-    this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, 'renderChart');
-  },
-
-  renderChart() {
-    let [ el ] = this.$().toArray();
-    this.set('d3el', select(el));
-  }
+  'with-transition': true
 });

--- a/addon/components/ember-sparkles/pie-chart.js
+++ b/addon/components/ember-sparkles/pie-chart.js
@@ -1,23 +1,11 @@
 import Ember from 'ember';
-import { select } from 'd3-selection';
 import layout from '../../templates/components/ember-sparkles/pie-chart';
 
 export default Ember.Component.extend({
   layout,
-  tagName: 'g',
-  classNames: ['ember-sparkles--pie-chart'],
+  tagName: '',
   'with-transition': true,
   'with-arc-labels': false,
-
-  didInsertElement() {
-    this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, 'renderChart');
-  },
-
-  renderChart() {
-    let [ el ] = this.$().toArray();
-    this.set('d3el', select(el));
-  },
 
   transformLegend(d, i) {
     return `translate(0,${i * 20})`;

--- a/addon/templates/components/ember-sparkles/bar-chart.hbs
+++ b/addon/templates/components/ember-sparkles/bar-chart.hbs
@@ -1,51 +1,46 @@
-{{#if d3el}}
-
+{{#d3-graph classNames="ember-sparkles--bar-chart" as |d3|}}
   {{!-- create x axis --}}
 
-  {{shhh (compute (pipe
-      (d3-append 'g')
-      (d3-attr 'class' 'x axis')
-      (d3-attr 'transform' (i 'translate(0,${h})' h=height))
-    ) d3el)
-  }}
+  {{d3.graph (pipe
+    (d3-append 'g')
+    (d3-attr 'class' 'x axis')
+    (d3-attr 'transform' (i 'translate(0,${h})' h=height))
+  )}}
 
   {{!-- select / call x axis function on d3 selection --}}
 
   {{#with (ember-sparkles/axis xScale position='bottom' tickFormat=(or tick-format '%Y-%m-%d')) as |axis|}}
-    {{shhh (compute (pipe
-        (d3-select-all '.x.axis')
-        (if with-transition (d3-transition transition) (d3-noop))
-        (d3-call axis)
-      ) d3el)
-    }}
+    {{d3.graph (pipe
+      (d3-select-all '.x.axis')
+      (if with-transition (d3-transition transition) (d3-noop))
+      (d3-call axis)
+    )}}
   {{/with}}
 
   {{!-- create y axis --}}
 
-  {{shhh (compute (pipe
-      (d3-append 'g')
-      (d3-attr 'class' 'y axis')
-      (d3-append 'text')
-      (d3-attr 'transform' 'rotate(-90)')
-      (d3-attr 'y' 6)
-      (d3-attr 'dy' '0.7em')
-      (d3-style 'text-anchor' 'end')
-      (d3-text y-label)
-    ) d3el)
-  }}
+  {{d3.graph (pipe
+    (d3-append 'g')
+    (d3-attr 'class' 'y axis')
+    (d3-append 'text')
+    (d3-attr 'transform' 'rotate(-90)')
+    (d3-attr 'y' 6)
+    (d3-attr 'dy' '0.7em')
+    (d3-style 'text-anchor' 'end')
+    (d3-text y-label)
+  )}}
 
   {{!-- select / call y axis function on d3 selection --}}
 
   {{#with (ember-sparkles/axis yScale position='left' ticks=ticks width=width) as |axis|}}
-    {{shhh (compute  (pipe
-        (d3-select-all '.y.axis')
-        (if with-transition (d3-transition transition) (d3-noop))
-        (d3-call axis)
-      ) d3el)
-    }}
+    {{d3.graph (pipe
+      (d3-select-all '.y.axis')
+      (if with-transition (d3-transition transition) (d3-noop))
+      (d3-call axis)
+    )}}
   {{/with}}
 
-  {{shhh (compute (pipe
+  {{d3.graph (pipe
     (d3-select-all 'rect')
     (d3-data data)
     (d3-join 
@@ -79,7 +74,5 @@
         (d3-attr 'y' height)
         (d3-remove)
       )
-    )) d3el)
-  }}
-
-{{/if}}
+  ))}}
+{{/d3-graph}}

--- a/addon/templates/components/ember-sparkles/grouped-bar-chart.hbs
+++ b/addon/templates/components/ember-sparkles/grouped-bar-chart.hbs
@@ -1,11 +1,10 @@
-{{#if d3el}}
+{{#d3-graph classNames="ember-sparkles--grouped-bar-chart" as |d3|}}
   {{!-- x axis --}}
-  {{shhh (compute (pipe
-      (d3-append 'g')
-      (d3-attr 'class' 'x axis')
-      (d3-attr 'transform' (i 'translate(0,${h})' h=height))      
-    ) d3el)
-  }}
+  {{d3.graph (pipe
+    (d3-append 'g')
+    (d3-attr 'class' 'x axis')
+    (d3-attr 'transform' (i 'translate(0,${h})' h=height))      
+  )}}
 
   {{#with (ember-sparkles/axis xScale
       position='bottom'
@@ -13,17 +12,16 @@
       responsiveSkipIdx=(or responsive-skip-idx 1)
     ) as |axis|}}
 
-    {{shhh (compute (pipe
+    {{d3.graph (pipe
       (d3-select-all '.x.axis')
       (if with-transition (d3-transition transition) (d3-noop))
       (d3-call axis)
-      ) d3el)
-    }}
+    )}}
 
   {{/with}}
 
   {{!-- y axis --}}
-  {{shhh (compute (pipe
+  {{d3.graph (pipe
     (d3-append 'g')
     (d3-attr 'class' 'y axis')
     (d3-append 'text')
@@ -31,26 +29,23 @@
     (d3-attr 'transform' 'rotate(-90)')
     (d3-style 'text-anchor' 'end')
     (d3-text y-label)
-    ) d3el)
-  }}
+  )}}
 
   {{#with (ember-sparkles/axis yScale position='left' ticks=ticks width=width) as |axis|}}
-    {{shhh (compute (pipe
+    {{d3.graph (pipe
       (d3-select-all '.y.axis')
       (if with-transition (d3-transition transition) (d3-noop))
       (d3-call axis)
-      ) d3el)
-    }}
+    )}}
   {{/with}}
 
   {{!-- position vertical label programmatically based on height; -0.4*height is a nice default --}}
-  {{shhh (compute (pipe
+  {{d3.graph (pipe
     (d3-select-all '.vertical-label')
     (if with-transition (d3-transition transition) (d3-noop))
     (d3-attr 'y' (or vertical-label-dy 6))
     (d3-attr 'x' (or vertical-label-dx (mult -0.4 height)))
-    ) d3el)
-  }}
+  )}}
 
   {{#with (band-scale
     groupDomain
@@ -90,47 +85,46 @@
 
     ) as |renderOptions|}}
 
-        {{shhh (compute (pipe
-          (d3-select-all '.rect-group')
-          (d3-data data)
-          (d3-join
-            enter=(pipe
-              (d3-append 'g')
-              (d3-attr 'class' 'rect-group')
-              (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
+      {{d3.graph (pipe
+        (d3-select-all '.rect-group')
+        (d3-data data)
+        (d3-join
+          enter=(pipe
+            (d3-append 'g')
+            (d3-attr 'class' 'rect-group')
+            (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
+            (d3-select-all 'rect')
+            (d3-data outputAccessor)
+            (d3-join
+              enter=(pipe renderOptions.enterRect renderOptions.updateRect)
+            )
+          )
+          update=(pipe
+            (d3-call (pipe 
               (d3-select-all 'rect')
               (d3-data outputAccessor)
               (d3-join
                 enter=(pipe renderOptions.enterRect renderOptions.updateRect)
+                update=renderOptions.updateRect
+                exit=renderOptions.exitRect
               )
-            )
-            update=(pipe
-              (d3-call (pipe 
-                (d3-select-all 'rect')
-                (d3-data outputAccessor)
-                (d3-join
-                  enter=(pipe renderOptions.enterRect renderOptions.updateRect)
-                  update=renderOptions.updateRect
-                  exit=renderOptions.exitRect
-                )
-              ))
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
-            )
-            exit=(pipe
-              (d3-call (pipe
-                (d3-select-all 'rect')
-                (d3-data outputAccessor)
-                (d3-join
-                  update=renderOptions.exitRect
-                  exit=renderOptions.exitRect
-                )              
-              ))
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-remove)
-            )
-          )) d3el)
-        }}
+            ))
+            (if with-transition (d3-transition transition) (d3-noop))
+            (d3-attr 'transform' (pipe inputAccessor xScale (ember-sparkles/translate-x)))
+          )
+          exit=(pipe
+            (d3-call (pipe
+              (d3-select-all 'rect')
+              (d3-data outputAccessor)
+              (d3-join
+                update=renderOptions.exitRect
+                exit=renderOptions.exitRect
+              )              
+            ))
+            (if with-transition (d3-transition transition) (d3-noop))
+            (d3-remove)
+          )
+      ))}}
 
     {{/with}}
 
@@ -138,71 +132,66 @@
 
   {{!-- legend --}}
   {{#if with-legend}}
-    {{#with (compute
-      (pipe
-        (d3-append 'g')
-        (d3-attr 'class' 'legend')
-        (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 80)))
-      )
-      d3el
-    ) as |legend|}}
+  
+    {{#d3-graph (pipe
+      (d3-append 'g')
+      (d3-attr 'class' 'legend')
+      (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 80)))
+    ) as |d3|}}
 
-      {{shhh (compute (pipe
-          (d3-select-all 'rect')
-          (d3-data groupDomain)
-          (d3-join
-            enter=(pipe
-              (d3-append 'rect')
-              (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
-              (d3-attr 'width' 14)
-              (d3-attr 'height' 14)
-              (d3-style 'fill' colorScale)
-              (d3-attr 'opacity' 0)
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-attr 'transform' transformLegend)
-              (d3-attr 'opacity' 1)
-            )
-            update=(pipe
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-style 'fill' colorScale)
-            )
-            exit=(pipe
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
-              (d3-remove)
-            )
-          )) legend)
-      }}
+      {{d3.graph (pipe
+        (d3-select-all 'rect')
+        (d3-data groupDomain)
+        (d3-join
+          enter=(pipe
+            (d3-append 'rect')
+            (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
+            (d3-attr 'width' 14)
+            (d3-attr 'height' 14)
+            (d3-style 'fill' colorScale)
+            (d3-attr 'opacity' 0)
+            (if with-transition (d3-transition transition) (d3-noop))
+            (d3-attr 'transform' transformLegend)
+            (d3-attr 'opacity' 1)
+          )
+          update=(pipe
+            (if with-transition (d3-transition transition) (d3-noop))
+            (d3-style 'fill' colorScale)
+          )
+          exit=(pipe
+            (if with-transition (d3-transition transition) (d3-noop))
+            (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
+            (d3-remove)
+          )
+      ))}}
 
-      {{shhh (compute (pipe
-          (d3-select-all 'text')
-          (d3-data groupDomain)
-          (d3-join
-            enter=(pipe
-              (d3-append 'text')
-              (d3-attr 'opacity' 0)
-              (d3-attr 'dx' '-3.8em')
-              (d3-attr 'dy' '1em')
-              (d3-style 'font-size' '10px')
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-text (d3-get))
-              (d3-attr 'transform' transformLegend)
-              (d3-attr 'opacity' 1)
-            )
+    {{d3.graph (pipe
+      (d3-select-all 'text')
+      (d3-data groupDomain)
+      (d3-join
+        enter=(pipe
+          (d3-append 'text')
+          (d3-attr 'opacity' 0)
+          (d3-attr 'dx' '-3.8em')
+          (d3-attr 'dy' '1em')
+          (d3-style 'font-size' '10px')
+          (if with-transition (d3-transition transition) (d3-noop))
+          (d3-text (d3-get))
+          (d3-attr 'transform' transformLegend)
+          (d3-attr 'opacity' 1)
+        )
 
-            update=(pipe
-              (d3-text (d3-get))
-            )
+        update=(pipe
+          (d3-text (d3-get))
+        )
 
-            exit=(pipe
-              (if with-transition (d3-transition transition) (d3-noop))
-              (d3-attr 'opacity' 0)
-              (d3-remove)
-            )
-          )) legend)
-      }}
-
-    {{/with}}
+        exit=(pipe
+          (if with-transition (d3-transition transition) (d3-noop))
+          (d3-attr 'opacity' 0)
+          (d3-remove)
+        )
+      ))}}
+      
+    {{/d3-graph}}
   {{/if}}
-
-{{/if}}
+{{/d3-graph}}

--- a/addon/templates/components/ember-sparkles/line-chart.hbs
+++ b/addon/templates/components/ember-sparkles/line-chart.hbs
@@ -1,63 +1,55 @@
-{{#if d3el}}
-  {{#with (hash
-    inputAccessor=(or input-accessor (d3-get 'ts'))
-    outputAccessor=(or output-accessor (d3-get 'Wh_sum'))
-    groupAccessor=(d3-get 'id')
-    xScale=(or x-scale (time-scale
-      (append 0 width)
-      (append 0 width)
-    ))
-    yScale=(or y-scale (linear-scale
-      (append 0 height)
-      (append height 0)
-    ))
-    tickFormat=(or tick-format '%Y-%m-%d')
-    colorScale=(or color-scale (cat-color-scale '10'))
+{{#with (hash
+  inputAccessor=(or input-accessor (d3-get 'ts'))
+  outputAccessor=(or output-accessor (d3-get 'Wh_sum'))
+  groupAccessor=(d3-get 'id')
+  xScale=(or x-scale (time-scale
+    (append 0 width)
+    (append 0 width)
+  ))
+  yScale=(or y-scale (linear-scale
+    (append 0 height)
+    (append height 0)
+  ))
+  tickFormat=(or tick-format '%Y-%m-%d')
+  colorScale=(or color-scale (cat-color-scale '10'))
 
-    transition=(or transition (ember-sparkles/transition duration=600 data=data))
-    ) as |options|}}
+  transition=(or transition (ember-sparkles/transition duration=600 data=data))
+  ) as |options|}}
 
-    {{!-- create x axis --}}
-
-    {{shhh (compute (pipe
-        (d3-append 'g')
-        (d3-attr 'class' 'x axis')
-        (d3-attr 'transform' (i 'translate(0,${h})' h=height))
-      ) d3el)
-    }}
+    {{#d3-graph classNames="ember-sparkles--line-chart" as |d3|}}
+      
+      {{!-- create x axis --}}
+    
+    {{d3.graph (pipe
+      (d3-append 'g')
+      (d3-attr 'class' 'x axis')
+      (d3-attr 'transform' (i 'translate(0,${h})' h=height))
+    )}}
 
     {{!-- select / call x axis function on d3 selection --}}
 
-    {{#with (ember-sparkles/axis options.xScale position='bottom' tickFormat='%Y-%m-%d') as |axis|}}
-      {{shhh (compute (pipe
-          (d3-select-all '.x.axis')
-          (if with-transition (d3-transition options.transition) (d3-noop))
-          (d3-call axis)
-        ) d3el)
-      }}
-    {{/with}}
+    {{d3.graph (pipe
+      (d3-select-all '.x.axis')
+      (if with-transition (d3-transition options.transition) (d3-noop))
+      (d3-call (ember-sparkles/axis options.xScale position='bottom' tickFormat='%Y-%m-%d'))
+    )}}
 
     {{!-- create y axis --}}
 
-    {{shhh (pipe
+    {{d3.graph (pipe
       (d3-append 'g')
       (d3-attr 'class' 'y axis')
-      ) d3el
-    }}
+    )}}
 
     {{!-- select / call y axis function on d3 selection --}}
 
-    {{#with (ember-sparkles/axis options.yScale position='left' ticks=ticks) as |axis|}}
-      {{shhh (compute (pipe
-          (d3-select-all '.y.axis')
-          (if with-transition (d3-transition options.transition) (d3-noop))
-          (d3-call axis)
-        ) d3el)
-      }}
-    {{/with}}
+    {{d3.graph (pipe
+      (d3-select-all '.y.axis')
+      (if with-transition (d3-transition options.transition) (d3-noop))
+      (d3-call (ember-sparkles/axis options.yScale position='left' ticks=ticks))
+    )}}
 
-
-    {{shhh (compute (pipe
+    {{d3.graph (pipe
       (d3-select-all '.line')
       (d3-data data)
       (d3-join
@@ -86,9 +78,7 @@
           (d3-style 'opacity' 0)
           (d3-remove)
         )
-      )) d3el)
-    }}
-
-
-  {{/with}}
-{{/if}}
+    ))}}
+    
+  {{/d3-graph}}
+{{/with}}

--- a/addon/templates/components/ember-sparkles/pie-chart.hbs
+++ b/addon/templates/components/ember-sparkles/pie-chart.hbs
@@ -1,13 +1,13 @@
-{{#if d3el}}
+{{#with (hash
+  arc=(d3-arc (sub radius 10) 0)
+  pie=(d3-pie valueFn=(pipe (r/get 'value')))
+  centerWidth=(div width 2)
+  centerHeight=(div height 2)
+) as |constructors|}}
 
-  {{#with (hash
-    arc=(d3-arc (sub radius 10) 0)
-    pie=(d3-pie valueFn=(pipe (r/get 'value')))
-    centerWidth=(div width 2)
-    centerHeight=(div height 2)
-  ) as |constructors|}}
+  {{#d3-graph classNames="ember-sparkles--pie-chart" as |d3|}}
 
-    {{shhh (compute (pipe
+    {{d3.graph (pipe
       (d3-select-all 'path')
       (d3-data (compute constructors.pie data))
       (d3-join
@@ -32,10 +32,9 @@
           (d3-attr 'opacity' 0)
           (d3-remove)
         )
-      )) d3el)
-    }}
+    ))}}
 
-    {{shhh (compute (pipe
+    {{d3.graph (pipe
       (d3-select-all '.percentage')
       (d3-data (compute constructors.pie data))
       (d3-join
@@ -58,43 +57,44 @@
           (d3-attr 'opacity' 0)
           (d3-remove)
         )
-      )) d3el)
-    }}
-  {{/with}}
+    ))}}
 
-  {{#with (compute (pipe
-      (d3-append 'g')
-      (d3-attr 'class' 'legend')
-      (d3-attr 'opacity' 0)
-      (d3-attr 'transform' (i 'translate(${w}, 18)' w=(mult width 0.99)))
-      (d3-attr 'opacity' 1)
-  ) d3el) as |legend|}}
+  {{/d3-graph}}
 
-    {{shhh (compute (pipe
-      (d3-select-all 'circle')
-      (d3-data domain)
-      (d3-join
-        enter=(pipe
-          (d3-append 'circle')
-          (d3-style 'fill' colorScale)
-          (if with-transition (d3-transition transition) (d3-noop))
-          (d3-attr 'transform' (i 'translate(${w}, 18)' w=(sub width 18)))
-          (d3-attr 'r' (div radius 25))
-          (d3-attr 'transform' transformLegend)
-        )
-        update=(pipe
-          (if with-transition (d3-transition transition) (d3-noop))
-          (d3-style 'fill' colorScale)
-        )
-        exit=(pipe
-          (if with-transition (d3-transition transition) (d3-noop))
-          (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
-          (d3-remove)
-        )
-      )) legend)
-    }}
+{{/with}}
 
-    {{shhh (compute (pipe
+{{#d3-graph (pipe
+    (d3-append 'g')
+    (d3-attr 'class' 'legend')
+    (d3-attr 'opacity' 0)
+    (d3-attr 'transform' (i 'translate(${w}, 18)' w=(mult width 0.99)))
+    (d3-attr 'opacity' 1)
+) as |d3|}}
+
+  {{d3.graph (pipe
+    (d3-select-all 'circle')
+    (d3-data domain)
+    (d3-join
+      enter=(pipe
+        (d3-append 'circle')
+        (d3-style 'fill' colorScale)
+        (if with-transition (d3-transition transition) (d3-noop))
+        (d3-attr 'transform' (i 'translate(${w}, 18)' w=(sub width 18)))
+        (d3-attr 'r' (div radius 25))
+        (d3-attr 'transform' transformLegend)
+      )
+      update=(pipe
+        (if with-transition (d3-transition transition) (d3-noop))
+        (d3-style 'fill' colorScale)
+      )
+      exit=(pipe
+        (if with-transition (d3-transition transition) (d3-noop))
+        (d3-attr 'transform' (i 'translate(${w},18)' w=(sub width 18)))
+        (d3-remove)
+      )
+    ))}}
+
+    {{d3.graph (pipe
       (d3-select-all 'text')
       (d3-data domain)
       (d3-join
@@ -117,9 +117,6 @@
           (if with-transition (d3-transition transition) (d3-noop))
           (d3-remove)
         )
-      )) legend)
-    }}
+    ))}}
 
-  {{/with}}
-
-{{/if}}
+{{/d3-graph}}

--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-sparkles'
+  name: 'ember-sparkles',
+  included: function() {
+    this._super.included.apply(this, arguments);
+  }
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,12 @@
 
 module.exports = {
   name: 'ember-sparkles',
-  included: function() {
+  included: function(app) {
+    if (app.app) {
+      app = app.app;
+    }
+    this.app = app;
+
     this._super.included.apply(this, arguments);
   }
 };

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-d3-shape": "0.9.4-4.1.1.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-composable-helpers": "0.27.0",
-    "ember-d3-helpers": "0.6.0",
+    "ember-d3-helpers": "0.5.6",
     "ember-interpolate-helper": "0.1.1",
     "ember-math-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-d3-shape": "0.9.4-4.1.1.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-composable-helpers": "0.27.0",
-    "ember-d3-helpers": "0.5.5",
+    "ember-d3-helpers": "0.6.0",
     "ember-interpolate-helper": "0.1.1",
     "ember-math-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-d3-shape": "0.9.4-4.1.1.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-composable-helpers": "0.27.0",
-    "ember-d3-helpers": "0.5.6",
+    "ember-d3-helpers": "LocusEnergy/ember-d3-helpers#69f84f8b1fdad70a2664935b3b25441cfe82862e",
     "ember-interpolate-helper": "0.1.1",
     "ember-math-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-cli-d3-shape": "0.9.4-4.1.1.0",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-composable-helpers": "0.27.0",
-    "ember-d3-helpers": "LocusEnergy/ember-d3-helpers#69f84f8b1fdad70a2664935b3b25441cfe82862e",
+    "ember-d3-helpers": "0.5.7",
     "ember-interpolate-helper": "0.1.1",
     "ember-math-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.6",


### PR DESCRIPTION
Upgraded all of the graphs to use `{{d3-graph}}`.

Must release https://github.com/LocusEnergy/ember-d3-helpers/pull/20 before this can be merged.
