### PR TITLE
Ember v2.15.0 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ember-interpolate-helper": "1.0.0",
     "ember-lodash": "0.0.7",
     "ember-math-helpers": "~2.0.5",
-    "ember-reactive-helpers": "0.4.0",
+    "ember-reactive-helpers": "~0.5.0",
     "ember-resize": "0.0.13",
     "ember-truth-helpers": "1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -59,15 +59,15 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-composable-helpers": "2.0.0",
+    "ember-composable-helpers": "^2.0.0",
     "ember-d3": "^0.3.2",
-    "ember-d3-helpers": "0.5.14",
-    "ember-interpolate-helper": "1.0.0",
-    "ember-lodash": "0.0.7",
+    "ember-d3-helpers": "^0.5.14",
+    "ember-interpolate-helper": "^1.0.0",
+    "ember-lodash": "^0.0.7",
     "ember-math-helpers": "~2.0.5",
     "ember-reactive-helpers": "~0.5.0",
-    "ember-resize": "0.0.13",
-    "ember-truth-helpers": "1.3.0"
+    "ember-resize": "^0.0.13",
+    "ember-truth-helpers": "^1.3.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-sparkles",
-  "version": "0.4.17",
+  "version": "0.5.0",
   "description": "htmlbars D3 library for Ember 2.5+",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
* Update ember-reactive-helpers to ~0.5.0 
* Bump version to 0.5.0